### PR TITLE
Make crackme06e behave in a similar fashion to crackme06

### DIFF
--- a/crackme06e.c
+++ b/crackme06e.c
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
         return -1;
     }
 
-    if (strncmp("leotindall.com", buffer, 16) != 0) {
+    if (strncmp("leotindall.com", buffer, 14) != 0) {
         fail();
     }
     


### PR DESCRIPTION
First of all, thank you for the great tutorial and the introductory crackmes.
It usually work with ARM assembly and your tutorials got me up and running with x86 disassembly really quickly!

The strncmp here expects 16 characters where the length of "leotindall.com" is only 14.
Since most text editors append '\n' at the end of text files, whenever the user creates a text file containing "leotindall.com" and passing it as an argument, the verification check fails.
The only way I got the original crackme06e to work is by manually replacing the \n at the end of the input text file by a \0 using a hex editor.

This change fixes that problem as I think this was the main intention. Also passing 16 when comparing "leotindall.com" can lead to reading 1 unallocated byte when the user input file is longer than 15 bytes.