### PR TITLE
Strip debug information from binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CCFLAGS64 := $(CCFLAGS) -m64
 # Build 64 bit binaries
 %.64: %.c
 	$(CC) $(CCFLAGS64) $< -o $@
-	objcopy -N FILE $@
+	objcopy -g $@
 
 # Determine all C programs in directory
 SRCS = $(wildcard *.c)


### PR DESCRIPTION
Replaced objcopy parameter "-N FILE" with -g to strip all debug
information and not just the FILE label since not all compilers
use FILE to store source information. This should get rid of
all source references.